### PR TITLE
Prevent restarting the IRCd via SIGINT from blocking signals.

### DIFF
--- a/src/ircd_signal.c
+++ b/src/ircd_signal.c
@@ -134,4 +134,6 @@ setup_signals(void)
   act.sa_handler = sigchld_handler;
   sigaddset(&act.sa_mask, SIGCHLD);
   sigaction(SIGCHLD, &act, 0);
+
+	sigprocmask(SIG_UNBLOCK, &act.sa_mask, NULL);
 }


### PR DESCRIPTION
Conflicts:
	ChangeLog
	include/serno.h
	src/ircd_signal.c