### PR TITLE
Add support for TLS DH params.

### DIFF
--- a/etc/example.conf
+++ b/etc/example.conf
@@ -123,6 +123,18 @@ serverinfo {
 	 *	E-mail: you@domain.com
 	 */
 	#ssl_certificate_file = "/usr/local/ircd/etc/cert.pem";
+
+	/*
+	 * diffie-hellman parameters: the path to the file containing our
+	 * DH parameters for ephemeral session key support.
+	 *
+	 * Create a 2048 bit DH parameters file. The key size should be the same as
+	 * your RSA key.
+	 *
+	 *	openssl dhparam -out dhparam.pem 2048
+	 *
+	 */
+	#dh_params_file = "/usr/local/ircd/etc/dhparam.pem";
 };
 
 /*

--- a/etc/example.conf.quick
+++ b/etc/example.conf.quick
@@ -48,6 +48,7 @@ serverinfo {
 	max_clients = 512;
 	#rsa_private_key_file = "/usr/local/ircd/etc/rsa.key";
 	#ssl_certificate_file = "/usr/local/ircd/etc/cert.pem";
+	#dh_params_file = "/usr/local/ircd/etc/dhparam.pem";
 };
 
 /* admin {}: contains admin information about the server. (OLD A:) */

--- a/etc/example.efnet.conf
+++ b/etc/example.efnet.conf
@@ -107,6 +107,18 @@ serverinfo {
 	 *	chmod 0644 rsa.pub
 	 */
 	#rsa_private_key_file = "/usr/local/ircd/etc/rsa.key";
+
+	/*
+	 * diffie-hellman parameters: the path to the file containing our
+	 * DH parameters for ephemeral session key support.
+	 *
+	 * Create a 2048 bit DH parameters file. The key size should be the same as
+	 * your RSA key.
+	 *
+	 *	openssl dhparam -out dhparam.pem 2048
+	 *
+	 */
+	#dh_params_file = "/usr/local/ircd/etc/dhparam.pem";
 };
 
 /*

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -452,6 +452,8 @@ struct server_info
 #ifdef HAVE_LIBCRYPTO
   char *rsa_private_key_file;
   RSA *rsa_private_key;
+  char *dh_params_file;
+  DH *dh_params;
   SSL_CTX *ctx;
 #endif
   char *sid;

--- a/src/ircd_lexer.l
+++ b/src/ircd_lexer.l
@@ -289,6 +289,7 @@ rsa_private_key_file		{ return RSA_PRIVATE_KEY_FILE; }
 rsa_public_key_file		{ return RSA_PUBLIC_KEY_FILE; }
 ssl 				{ return T_SSL; }
 ssl_certificate_file        { return SSL_CERTIFICATE_FILE; }
+dh_params_file		{ return DH_PARAMS_FILE; }
 send_password	{ return SEND_PASSWORD; }
 sendq		{ return SENDQ; }
 serverhide	{ return SERVERHIDE; }

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -1892,6 +1892,8 @@ set_default_conf(void)
 #ifdef HAVE_LIBCRYPTO
   ServerInfo.rsa_private_key = NULL;
   ServerInfo.rsa_private_key_file = NULL;
+  ServerInfo.dh_params = NULL;
+  ServerInfo.dh_params_file = NULL;
 #endif
 
   /* ServerInfo.name is not rehashable */
@@ -2807,6 +2809,15 @@ clear_out_old_conf(void)
 
   MyFree(ServerInfo.rsa_private_key_file);
   ServerInfo.rsa_private_key_file = NULL;
+
+  if (ServerInfo.dh_params != NULL)
+  {
+    DH_free(ServerInfo.dh_params);
+    ServerInfo.dh_params = NULL;
+  }
+
+  MyFree(ServerInfo.dh_params_file);
+  ServerInfo.dh_params_file = NULL;
 #endif
 
   /* clean out old resvs from the conf */


### PR DESCRIPTION
This patch adds support for loading a DH params file, which adds support
for ephemeral session keys for client and server TLS connections.