### PR TITLE
Add support for Elliptic Curve Diffie-Hellman.

### DIFF
--- a/etc/example.conf
+++ b/etc/example.conf
@@ -135,6 +135,13 @@ serverinfo {
 	 *
 	 */
 	#dh_params_file = "/usr/local/ircd/etc/dhparam.pem";
+
+	/*
+	 * elliptic curve diffie-hellman curve: specify the curve for ephemeral
+	 * ECDH session key support.
+	 *
+	 */
+	#ecdh_curve = "prime256v1";
 };
 
 /*

--- a/etc/example.conf.quick
+++ b/etc/example.conf.quick
@@ -49,6 +49,7 @@ serverinfo {
 	#rsa_private_key_file = "/usr/local/ircd/etc/rsa.key";
 	#ssl_certificate_file = "/usr/local/ircd/etc/cert.pem";
 	#dh_params_file = "/usr/local/ircd/etc/dhparam.pem";
+	#ecdh_curve = "prime256v1";
 };
 
 /* admin {}: contains admin information about the server. (OLD A:) */

--- a/etc/example.efnet.conf
+++ b/etc/example.efnet.conf
@@ -119,6 +119,13 @@ serverinfo {
 	 *
 	 */
 	#dh_params_file = "/usr/local/ircd/etc/dhparam.pem";
+
+	/*
+	 * elliptic curve diffie-hellman curve: specify the curve for ephemeral
+	 * ECDH session key support.
+	 *
+	 */
+	#ecdh_curve = "prime256v1";
 };
 
 /*

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -458,6 +458,8 @@ struct server_info
   RSA *rsa_private_key;
   char *dh_params_file;
   DH *dh_params;
+  char *ecdh_curve;
+  EC_KEY *ecdh_key;
   SSL_CTX *ctx;
 #endif
   char *sid;

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -529,6 +529,10 @@ init_ssl(void)
   SSL_CTX_set_session_cache_mode(ServerInfo.ctx, SSL_SESS_CACHE_OFF);
   SSL_CTX_set_cipher_list(ServerInfo.ctx, "kEECDH+HIGH:kEDH+HIGH:HIGH:!RC4:!aNULL");
 
+#ifdef SSL_OP_SINGLE_ECDH_USE
+  SSL_CTX_set_options(ServerInfo.ctx, SSL_OP_SINGLE_ECDH_USE);
+#endif
+
   bio_spare_fd = save_spare_fd("SSL private key validation");
 #endif /* HAVE_LIBCRYPTO */
 }

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -527,6 +527,7 @@ init_ssl(void)
   SSL_CTX_set_options(ServerInfo.ctx, SSL_OP_TLS_ROLLBACK_BUG|SSL_OP_ALL);
   SSL_CTX_set_verify(ServerInfo.ctx, SSL_VERIFY_PEER, always_accept_verify_cb);
   SSL_CTX_set_session_cache_mode(ServerInfo.ctx, SSL_SESS_CACHE_OFF);
+  SSL_CTX_set_cipher_list(ServerInfo.ctx, "kEECDH+HIGH:kEDH+HIGH:HIGH:!RC4:!aNULL");
 
   bio_spare_fd = save_spare_fd("SSL private key validation");
 #endif /* HAVE_LIBCRYPTO */

--- a/src/ircd_lexer.l
+++ b/src/ircd_lexer.l
@@ -290,6 +290,7 @@ rsa_public_key_file		{ return RSA_PUBLIC_KEY_FILE; }
 ssl 				{ return T_SSL; }
 ssl_certificate_file        { return SSL_CERTIFICATE_FILE; }
 dh_params_file		{ return DH_PARAMS_FILE; }
+ecdh_curve			{ return ECDH_CURVE; }
 send_password	{ return SEND_PASSWORD; }
 sendq		{ return SENDQ; }
 server          { return T_SERVER; }

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -1897,6 +1897,8 @@ set_default_conf(void)
   ServerInfo.rsa_private_key_file = NULL;
   ServerInfo.dh_params = NULL;
   ServerInfo.dh_params_file = NULL;
+  ServerInfo.ecdh_curve = NULL;
+  ServerInfo.ecdh_key = NULL;
 #endif
 
   /* ServerInfo.name is not rehashable */
@@ -2821,6 +2823,15 @@ clear_out_old_conf(void)
 
   MyFree(ServerInfo.dh_params_file);
   ServerInfo.dh_params_file = NULL;
+
+  if (ServerInfo.ecdh_key != NULL)
+  {
+    EC_KEY_free(ServerInfo.ecdh_key);
+    ServerInfo.ecdh_key = NULL;
+  }
+
+  MyFree(ServerInfo.ecdh_curve);
+  ServerInfo.ecdh_curve = NULL;
 #endif
 
   /* clean out old resvs from the conf */


### PR DESCRIPTION
This patch adds support for elliptic curve Diffie-Hellman for ephemeral
key exchange between client and server.

We add the configuration option `ecdh_curve` in the `serverinfo` block
to allow the user to specify a preferred curve.

Thanks to Yawning on #tor-dev at OFTC for answering the questions I have
had.